### PR TITLE
Update 1. Train_llama2_70b.ipynb (fix small typo)

### DIFF
--- a/3_llama2_llm_training/1_llama2_70b_pretraining/1. Train_llama2_70b.ipynb
+++ b/3_llama2_llm_training/1_llama2_70b_pretraining/1. Train_llama2_70b.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "## Train Llama2 70b SageMaker using AWS Trainium instances\n",
     "\n",
-    "This example helps to pertrain a Llama 70b model using NeuronX Distributed on trainium instances. NeuronX Distributed is a package for supporting different distributed training/inference mechanism for Neuron devices. It would provide xla friendly implementations of some of the more popular distributed training/inference techniques. The library can be easily installed via pip.\n",
+    "This example helps to pretrain a Llama 70b model using NeuronX Distributed on trainium instances. NeuronX Distributed is a package for supporting different distributed training/inference mechanism for Neuron devices. It would provide xla friendly implementations of some of the more popular distributed training/inference techniques. The library can be easily installed via pip.\n",
     "\n",
     "In this notebook, we showcase to pretrain a Llama2 70B model by using the tensor parallel, pipeline parallel, sequence parallel, activation checkpoint as well as constant mask optimization in the neuronx-distributed package.\n",
     "\n"


### PR DESCRIPTION
Fixed small typo where it was mentioned "pertrained" instead of "pretrained".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
